### PR TITLE
Fixed double addition of self.vtop when calculating view line

### DIFF
--- a/src/editor/render.rs
+++ b/src/editor/render.rs
@@ -676,7 +676,7 @@ impl Editor {
             let window_cursor_x = window.cursor_x;
             let window_cursor_y = window.cursor_y;
 
-            let display_column = if let Some(line) = self.view_line(window.vtop + window_cursor_y) {
+            let display_column = if let Some(line) = self.view_line(window_cursor_y) {
                 let line = line.trim_end_matches('\n');
                 crate::unicode::char_to_column(line, window_cursor_x)
             } else {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue Number: #57 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR -->

- When moving the view, self.vtop is added in only once when calculating the view line

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change -->
