### PR TITLE
Fixed buffer not completely re-rendering on theme change

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -92,4 +92,6 @@ pub enum Action {
     EnterMode(Mode),
     /// Store the first key in a multi-character command sequence
     SetWaitingKey(Box<KeyAction>),
+    /// Force a complete redraw of the editor
+    Redraw,
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -511,8 +511,12 @@ impl Editor {
             if cmd == "theme" {
                 let theme_loader = ThemeLoader::new(&[Config::path("")]);
                 if let Some(theme_name) = parsed.args.first() {
-                    if let Ok(theme) = theme_loader.load(theme_name) {
-                        self.theme = theme;
+                    if let Ok(new_theme) = theme_loader.load(theme_name) {
+                        self.theme = new_theme.clone();
+                        if let Ok(new_highlighter) = Highlighter::new(&new_theme) {
+                            self.highlighter = new_highlighter;
+                            actions.push(Action::Redraw);
+                        }
                     } else {
                         self.last_error = Some(format!("Could not load theme '{theme_name}'"));
                     }
@@ -660,6 +664,15 @@ impl Editor {
         self.last_error = None;
 
         match action {
+            Action::Redraw => {
+                // Clear the screen
+                self.stdout
+                    .execute(terminal::Clear(terminal::ClearType::All))?;
+                // Reset and clear the render buffer
+                buffer.clear();
+                // Re-render everything
+                self.render(buffer)?;
+            }
             Action::Quit(force) => {
                 if *force {
                     return Ok(true);


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue -->

Issue Number: #71 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR -->

- When changing themes using `:theme`, the editor's buffer will now properly re-render, leaving behind no artifacts from the previous theme.

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change -->
